### PR TITLE
Correct processor for cube Orange

### DIFF
--- a/autopilot/the-cube-module-overview.md
+++ b/autopilot/the-cube-module-overview.md
@@ -6,7 +6,7 @@
 
 * Black, Green, Blue, Purple STM32F427; flash 2MB, RAM 256KB.
 * Yellow STM32F777; flash 2MB, Ram 512KB.
-* Orange STM32F427; flash 2MB, RAM 1MB.
+* Orange STM32H743; flash 2MB, RAM 1MB.
 * On-board 16KB SPI FRAM
 * MPU9250 or ICM 20649 integrated accelerometer / gyro.
 * MS5611 Barometer


### PR DESCRIPTION
Change processor for Cube Orange from STM32f427 to STM32H743