### PR TITLE
Update the-cube-module-overview.md

### DIFF
--- a/autopilot/the-cube-module-overview.md
+++ b/autopilot/the-cube-module-overview.md
@@ -214,13 +214,15 @@ _**Connector Series**_
   * Power Module: [Molex Clik-Mate](http://www.molex.com/molex/products/family?channel=products&chanName=family&key=clikmate_wiretoboard_connectors) 2 mm for both main and backup power \(on bottom of board?\)
   
 **The Cube**
-  Mechanical: 30x30 mm M3 mounting hole pattern, 35x35 mm footprint 80 position DF17 connector. Carries _all_ autopilot interface connections.
+
+Mechanical: 30x30 mm M3 mounting hole pattern, 35x35 mm footprint 80 position DF17 connector. Carries _all_ autopilot interface connections.
   * Minimal \(read: really minimal\) electrical protection
   * No power management
   * 3.8 to 5.7V operation \(absolute maximum ratings\) 
   * 4.0 to 5.5V operation \(compliant rating\)
   
 **The Cube IO**
+
 Total connectivity
   * I2C2
   * 2x CAN: CAN1 and CAN2
@@ -229,6 +231,7 @@ Total connectivity
   * 1x HMI: USB extender
 
 **Power 6 pos \(ClikMate 6 pos 2.0mm\)**
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
 | :--- | :--- | :--- | :--- | :--- | 
 | 1 | VDD 5V Brick | in | red/gray | Supply from Brick to AP |

--- a/autopilot/the-cube-module-overview.md
+++ b/autopilot/the-cube-module-overview.md
@@ -182,15 +182,19 @@ For each of the components listed, the input voltage ranges over which the devic
 The Cube provides power routing, over/under voltage detection and protection, filtering, switching, current-limiting and transient suppression for peripherals. Power outputs to peripherals feature ESD and EMI filtering, and the power supply protection scheme ensures that no more than 5.5V is presented to peripheral devices. Power is disconnected from the peripherals when the available supply voltage falls below 2.7V, or rises above approximately 5.7V. Peripheral power is split into two groups: \* Serial 1 has a private 1.5A current limit, intended for powering a low power 
 
 **Telemetry radio.**
+
 This output is separately EMI filtered and draws directly from the USB / Brick inputs. Peak power draw on this port should not exceed 2A, which should be sufficient for a 30dBm transmitter of reasonable efficiency. \* All other peripherals share a 1A current limit and a single power switch. Peak power draw on this port should not exceed 1.5A. Each group is individually switched under software control. The Spektrum / DSM R/C interface draws power ***from its own regulator***, rather than from either of the groups above. This port is switched under software control so that Spektrum / DSM binding can be implemented. Spektrum receivers generally draw ~25mA. S.Bus and CPPM receivers are powered by a dedicated power supply. Please do not connect any servos to this power, only an RX by itself.
 
 **Capacitor Backup**
+
 Both the FMU and IO microcontrollers feature Capacitor-backed real-time clocks and SRAM. The on-board backup Capacitor has capacity sufficient for the intended use of the clock and SRAM, which is to provide storage to permit orderly recovery from unintended power loss or other causes of in-air restarts. The capacitors are recharged from the FMU 3.3V rail. this will only function in the event of software existing to support this feature.
 
 **Voltage, Current and Fault Sensing**
+
 The battery voltage and current reported ***by both bricks*** can be measured by the FMU. In addition, the 5V unregulated supply rail can be measured \(to detect brown- out conditions\). IO can measure the servo power rail voltage. Over-current conditions on the peripheral power ports can be detected by the FMU. Hardware lock-out prevents damage due to persistent short-circuits on these ports. The lock- out can be reset by FMU software. The under/over voltage supervisor for FMU provides an output that is used to hold FMU in reset during brown-out events.
 
 ### EMI Filtering and Transient Protection \(on the normal Base Board, must be specified for externally supplied base boards.\)
+
 EMI filtering is provided at key points in the system using high-insertion-loss pass- through filters. These filters are paired with TVS diodes at the peripheral connectors to suppress power transients. Reverse polarity protection is provided at each of the power inputs. USB signals are filtered and terminated with a combined termination/TVS array. Most digital peripheral signals \(all PWM outputs, serial ports, I2C port\) are driven using ESD-enhanced buffers and feature series blocking resistors to reduce the risk of damage due to transients or accidental misconnections.
 
 ## The Cube Series Interface Spec
@@ -235,6 +239,7 @@ Total connectivity
 | 6 | GND | - | black | GND connection |
 
 **Backup Power 6 pos** 
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** | 
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | VDD 5V Brick | in | red / gray | Supply from Brick to AP |
@@ -247,6 +252,7 @@ Total connectivity
 **I2C - 4 pos \(1 fitted as a stand alone, I2C_2, \(old internal\)**
 
 1. _connector: I2C2 bus_
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** | 
 | :--- | :--- | :--- | :--- | :--- | 
 | 1 | VCC\_5V | out | red / gray | Supply to peripheral from AP |
@@ -257,6 +263,7 @@ Total connectivity
 **CAN \(2 fitted\)**
 
 1. _connectors: CAN1 and CAN2 buses_ 
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | VCC\_5V | out | red / gray | Supply to peripheral from AP |
@@ -267,6 +274,7 @@ Total connectivity
 **UART GENERIC \(autopilot side\)**
 
 _2 connectors: TELEM1, TELEM2_
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | VCC\_5V | out | red / gray | Supply to GPS from AP |
@@ -279,6 +287,7 @@ _2 connectors: TELEM1, TELEM2_
 **UART GPS \(autopilot side, I2C is the original “External” bus\)**
 
 _1 connector: GPS_
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | VCC\_5V | in | red | Supply to GPS from AP |
@@ -293,6 +302,7 @@ _1 connector: GPS_
 **UART 4 \(I2C 2, the original “Internal” bus\)**
 
 _1 connector: GPS_
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | VCC\_5V | out | red / gray | Supply to GPS from AP |
@@ -305,6 +315,7 @@ _1 connector: GPS_
 **UART 5 \(Debug and S.Bus out\)**
 
 _Original Carrier board_
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | S.Bus Out | out | | 3.3V-5.0V TTL level, TX of AP |
@@ -315,7 +326,9 @@ _Original Carrier board_
 | 6 | GND | out | | GND |
 
 **S.Bus out**
+
 New ADSB Carrier board
+
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | S.Bus Out | out | | 3.3V-5.0V TTL level, TX of AP |

--- a/autopilot/the-cube-module-overview.md
+++ b/autopilot/the-cube-module-overview.md
@@ -175,166 +175,181 @@ For each of the components listed, the input voltage ranges over which the devic
 
 |  | **Brick port** | **Aux port** | **USB port** | **Servo rail** |
 | :--- | :--- | :--- | :--- | :--- |
-
-
 | **FMU** | 4 - 5.7V | 4 - 5.7V | 4 - 5.7V | NIL |
-| :--- | :--- | :--- | :--- | :--- |
-
-
 | **IO** | 4 - 5.7V | 4 - 5.7V | 4 - 5.7V | 4 - 10.5V |
+| **Peripherals** | 4 - 5.7V<br/>2.5A max | 4 - 5.7V<br/>2.5A max | 4 - 5.7V<br/>2.5A max | NIL|
+
+The Cube provides power routing, over/under voltage detection and protection, filtering, switching, current-limiting and transient suppression for peripherals. Power outputs to peripherals feature ESD and EMI filtering, and the power supply protection scheme ensures that no more than 5.5V is presented to peripheral devices. Power is disconnected from the peripherals when the available supply voltage falls below 2.7V, or rises above approximately 5.7V. Peripheral power is split into two groups: \* Serial 1 has a private 1.5A current limit, intended for powering a low power 
+
+**Telemetry radio.**
+This output is separately EMI filtered and draws directly from the USB / Brick inputs. Peak power draw on this port should not exceed 2A, which should be sufficient for a 30dBm transmitter of reasonable efficiency. \* All other peripherals share a 1A current limit and a single power switch. Peak power draw on this port should not exceed 1.5A. Each group is individually switched under software control. The Spektrum / DSM R/C interface draws power ***from its own regulator***, rather than from either of the groups above. This port is switched under software control so that Spektrum / DSM binding can be implemented. Spektrum receivers generally draw ~25mA. S.Bus and CPPM receivers are powered by a dedicated power supply. Please do not connect any servos to this power, only an RX by itself.
+
+**Capacitor Backup**
+Both the FMU and IO microcontrollers feature Capacitor-backed real-time clocks and SRAM. The on-board backup Capacitor has capacity sufficient for the intended use of the clock and SRAM, which is to provide storage to permit orderly recovery from unintended power loss or other causes of in-air restarts. The capacitors are recharged from the FMU 3.3V rail. this will only function in the event of software existing to support this feature.
+
+**Voltage, Current and Fault Sensing**
+The battery voltage and current reported ***by both bricks*** can be measured by the FMU. In addition, the 5V unregulated supply rail can be measured \(to detect brown- out conditions\). IO can measure the servo power rail voltage. Over-current conditions on the peripheral power ports can be detected by the FMU. Hardware lock-out prevents damage due to persistent short-circuits on these ports. The lock- out can be reset by FMU software. The under/over voltage supervisor for FMU provides an output that is used to hold FMU in reset during brown-out events.
+
+### EMI Filtering and Transient Protection \(on the normal Base Board, must be specified for externally supplied base boards.\)
+EMI filtering is provided at key points in the system using high-insertion-loss pass- through filters. These filters are paired with TVS diodes at the peripheral connectors to suppress power transients. Reverse polarity protection is provided at each of the power inputs. USB signals are filtered and terminated with a combined termination/TVS array. Most digital peripheral signals \(all PWM outputs, serial ports, I2C port\) are driven using ESD-enhanced buffers and feature series blocking resistors to reduce the risk of damage due to transients or accidental misconnections.
+
+## The Cube Series Interface Spec
+
+_Scope of this Document_
+_This document covers the complete interface standard and core mechanical, electrical and external connection options of The Cube module series. Sections marked as LT \(long term\) are intended to be kept stable to isolate vehicle from autopilot revisions._ 
+
+**Interface Standard**
+
+_**Connector Series**_
+
+  * Low density: 0.1” over mould Futaba keyed servo connectors \(Mfg. to be identified\)
+  * Cabling: AWG24, ribbon or round, iconic colour scheme
+  * Stack: [Hirose DF17, 80pos](https://www.hirose.com/product/document?clcode=&productname=&series=DF17&documenttype=Catalog&lang=en&documentid=D49657_en) 4 mm stacking height, 0.5 mm pitch, drop-proof
+  * High density: [JST-GH](http://www.jst-mfg.com/product/detail_e.php?series=105) 1.25 mm
+  * Cabling: AWG28, ribbon, iconic colour scheme
+  * Power Module: [Molex Clik-Mate](http://www.molex.com/molex/products/family?channel=products&chanName=family&key=clikmate_wiretoboard_connectors) 2 mm for both main and backup power \(on bottom of board?\)
+  
+**The Cube**
+  Mechanical: 30x30 mm M3 mounting hole pattern, 35x35 mm footprint 80 position DF17 connector. Carries _all_ autopilot interface connections.
+  * Minimal \(read: really minimal\) electrical protection
+  * No power management
+  * 3.8 to 5.7V operation \(absolute maximum ratings\) 
+  * 4.0 to 5.5V operation \(compliant rating\)
+  
+**The Cube IO**
+Total connectivity
+  * I2C2
+  * 2x CAN: CAN1 and CAN2
+  * 4x UART: TELEM1, TELEM2, GPS \(I2C 1 embedded\), SERIAL4 \(I2C 2 embedded\)
+  * 1x Console: CONSOLE \(SERIAL5\) 
+  * 1x HMI: USB extender
+
+**Power 6 pos \(ClikMate 6 pos 2.0mm\)**
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :--- | :--- | :--- | :--- | 
+| 1 | VDD 5V Brick | in | red/gray | Supply from Brick to AP |
+| 2 | VDD 5V Brick | in | red/gray | Supply from Brick to AP |
+| 3 | BATT\_CURRENT\_SENS\_PROT | in | black | Battery current connector |
+| 4 | BATT\_VOLTAGE\_SENS\_PROT | in | black | Battery voltage connector |
+| 5 | GND | - | black | GND connection |
+| 6 | GND | - | black | GND connection |
+
+**Backup Power 6 pos** 
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** | 
 | :--- | :--- | :--- | :--- | :--- |
+| 1 | VDD 5V Brick | in | red / gray | Supply from Brick to AP |
+| 2 | VDD 5V Brick | in | red / gray | Supply from Brick to AP |
+| 3 | AUX\_BATT\_CURRENT\_SENS | in | black | Aux Battery current connector |
+| 4 | AUX\_BATT\_VOLTAGE\_SENS | in | black | Aux Battery voltage connector |
+| 5 | GND | - | black | GND connection |
+| 6 | GND | - | black | GND connection |
 
+**I2C - 4 pos \(1 fitted as a stand alone, I2C_2, \(old internal\)**
 
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left"><b>Peripherals</b>
-      </th>
-      <th style="text-align:left">
-        <p>4 - 5.7V</p>
-        <p>2.5A max</p>
-      </th>
-      <th style="text-align:left">
-        <p>4 - 5.7V</p>
-        <p>2.5A max</p>
-      </th>
-      <th style="text-align:left">
-        <p>4 - 5.7V</p>
-        <p>2.5A max</p>
-      </th>
-      <th style="text-align:left">NIL</th>
-    </tr>
-  </thead>
-  <tbody></tbody>
-</table>The Cube provides power routing, over/under voltage detection and protection, filtering, switching, current-limiting and transient suppression for peripherals. Power outputs to peripherals feature ESD and EMI filtering, and the power supply protection scheme ensures that no more than 5.5V is presented to peripheral devices. Power is disconnected from the peripherals when the available supply voltage falls below 2.7V, or rises above approximately 5.7V. Peripheral power is split into two groups: \* Serial 1 has a private 1.5A current limit, intended for powering a low power \*\*Telemetry radio.\*\* This output is separately EMI filtered and draws directly from the USB / Brick inputs. Peak power draw on this port should not exceed 2A, which should be sufficient for a 30dBm transmitter of reasonable efficiency. \* All other peripherals share a 1A current limit and a single power switch. Peak power draw on this port should not exceed 1.5A. Each group is individually switched under software control. The Spektrum / DSM R/C interface draws power \*\*\\*from its own regulator\\*\*\*, rather than from either of the groups above. This port is switched under software control so that Spektrum / DSM binding can be implemented. Spektrum receivers generally draw ~25mA. S.Bus and CPPM receivers are powered by a dedicated power supply. Please do not connect any servos to this power, only an RX by itself. \*\*Capacitor Backup\*\* Both the FMU and IO microcontrollers feature Capacitor-backed real-time clocks and SRAM. The on-board backup Capacitor has capacity sufficient for the intended use of the clock and SRAM, which is to provide storage to permit orderly recovery from unintended power loss or other causes of in-air restarts. The capacitors are recharged from the FMU 3.3V rail. this will only function in the event of software existing to support this feature. \*\*Voltage, Current and Fault Sensing\*\* The battery voltage and current reported \*\*\\*by both bricks\\*\*\* can be measured by the FMU. In addition, the 5V unregulated supply rail can be measured \\(to detect brown- out conditions\\). IO can measure the servo power rail voltage. Over-current conditions on the peripheral power ports can be detected by the FMU. Hardware lock-out prevents damage due to persistent short-circuits on these ports. The lock- out can be reset by FMU software. The under/over voltage supervisor for FMU provides an output that is used to hold FMU in reset during brown-out events. \#\#\# EMI Filtering and Transient Protection \\(on the normal Base Board, must be specified for externally supplied base boards.\\) EMI filtering is provided at key points in the system using high-insertion-loss pass- through filters. These filters are paired with TVS diodes at the peripheral connectors to suppress power transients. Reverse polarity protection is provided at each of the power inputs. USB signals are filtered and terminated with a combined termination/TVS array. Most digital peripheral signals \\(all PWM outputs, serial ports, I2C port\\) are driven using ESD-enhanced buffers and feature series blocking resistors to reduce the risk of damage due to transients or accidental misconnections. \#\# The Cube Series Interface Spec \_Scope of this Document\_ \_This document covers the complete interface standard and core mechanical, electrical and external connection options of The Cube module series. Sections marked as LT \\(long term\\) are intended to be kept stable to isolate vehicle from autopilot revisions.\_ \*\*Interface Standard\*\* \_\*\*Connector Series\*\*\_ \* Low density: 0.1” over mould Futaba keyed servo connectors \\(Mfg. to be identified\\) \* Cabling: AWG24, ribbon or round, iconic colour scheme \* Stack: \[Hirose DF17,\]\(http://www.google.ch/url?sa=t&rct=j&q&esrc=s&source=web&cd=5&cad=rja&uact=8&ved=0CEoQFjAE&url=http%3A%2F%2Fwww.hirose.co.jp%2Fcataloge\_hp%2Fen\_DF17\_20130411.pdf&ei=ya8eU\_qbCoer7AbVjYD4Cw&usg=AFQjCNEe\_OW87i6iomdn0UDTl6d5UkUhiw&sig2=00Z8iCRQyAbvbU\_T63wEeQ&bvm=bv.62788935%2Cd.ZGU\) \[80pos,\]\(http://www.google.ch/url?sa=t&rct=j&q&esrc=s&source=web&cd=5&cad=rja&uact=8&ved=0CEoQFjAE&url=http%3A%2F%2Fwww.hirose.co.jp%2Fcataloge\_hp%2Fen\_DF17\_20130411.pdf&ei=ya8eU\_qbCoer7AbVjYD4Cw&usg=AFQjCNEe\_OW87i6iomdn0UDTl6d5UkUhiw&sig2=00Z8iCRQyAbvbU\_T63wEeQ&bvm=bv.62788935%2Cd.ZGU\) 4 mm stacking height, 0.5 mm pitch, drop-proof \* High density: \[JST-GH\]\(http://www.jst-mfg.com/product/detail\_e.php?series=105\) 1.25 mm \* Cabling: AWG28, ribbon, iconic colour scheme \* Power Module: \[Molex Clik-Mate\]\(http://www.molex.com/molex/products/family?channel=products&chanName=family&key=clikmate\_wiretoboard\_connectors\) 2 mm for both main and backup power \\( on bottom of board?\\) \*\*The Cube\*\* Mechanical: 30x30 mm M3 mounting hole pattern, 35x35 mm footprint 80 position DF17 connector. Carries \_all\_ autopilot interface connections. \* Minimal \\(read: really minimal\\) electrical protection \* No power management \* 3.8 to 5.7V operation \\(absolute maximum ratings\\) \* 4.0 to 5.5V operation \\(compliant rating\\) \*\*The Cube IO\*\* Total connectivity \* I2C2 \* 2x CAN: CAN1 and CAN2 \* 4x UART: TELEM1, TELEM2, GPS \\(I2C 1 embedded\\), SERIAL4\\(I2C 2 embedded\\) \* 1x Console: CONSOLE \\(SERIAL5\\) \* 1x HMI: USB extender \*\*Power 6 pos \\(ClikMate 6 pos 2.0mm\\)\*\* \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| VDD 5V Brick \| in \| red/gray \| Supply from Brick to AP \| \| 2 \| VDD 5V Brick \| in \| red/gray \| Supply from Brick to AP \| \| 3 \| BATT\\_CURRENT\\_SENS\\_PROT \| in \| black \| Battery current connector \| \| 4 \| BATT\\_VOLTAGE\\_SENS\\_PROT \| in \| black \| Battery voltage connector \| \| 5 \| GND \| - \| black \| GND connection \| \| 6 \| GND \| - \| black \| GND connection \| \*\*Backup Power 6 pos\*\* \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| VDD 5V Brick \| in \| red / gray \| Supply from Brick to AP \| \| 2 \| VDD 5V Brick \| in \| red / gray \| Supply from Brick to AP \| \| 3 \| AUX\\_BATT\\_CURRENT\\_SENS \| in \| black \| Aux Battery current connector \| \| 4 \| AUX\\_BATT\\_VOLTAGE\\_SENS \| in \| black \| Aux Battery voltage connector \| \| 5 \| GND \| - \| black \| GND connection \| \| 6 \| GND \| - \| black \| GND connection \| \*\*I2C - 4 pos \\(1 fitted as a stand alone, I2C\\_2, \\(old internal\\)\*\* 1. \_connector: I2C2 bus\_ \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| VCC\\_5V \| out \| red / gray \| Supply to peripheral from AP \| \| 2 \| SCL \| in/out \| blue / black \| SCL, 5V level, pull-up on AP \| \| 3 \| SDA \| in/out \| green / black \| SDA, 5V level, pull-up on AP \| \| 4 \| GND \| - \| black \| GND connection \| \*\*CAN \\(2 fitted\\)\*\* 1. \_connectors: CAN1 and CAN2 buses\_ \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| VCC\\_5V \| out \| red / gray \| Supply to peripheral from AP \| \| 2 \| CAN\\_H \| in/out \| yellow / black \| 12V \| \| 3 \| CAN\\_L \| in/out \| green / black \| 12V \| \| 4 \| GND \| - \| black \| GND connection \| \*\*UART GENERIC \\(autopilot side\\)\*\* \_2 connectors: TELEM1, TELEM2\_ \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| VCC\\_5V \| out \| red / gray \| Supply to GPS from AP \| \| 2 \| MCU\\_TX \| out \| yellow / black \| 3.3V-5.0V TTL level, TX of AP \| \| 3 \| MCU\\_RX \| in \| green / black \| 3.3V-5.0V TTL level, RX of AP \| \| 4 \| MCU\\_CTS \\(TX\\) \| out \| gray / black \| 3.3V-5.0V TTL level or TX of AP \| \| 5 \| MCU\\_RTS \\(RX\\) \| in \| gray / black \| 3.3V-5.0V TTL level or RX of AP \| \| 6 \| GND \| - \| black \| GND connection \| \*\*UART GPS \\(autopilot side, I2C is the original “External” bus\\)\*\* \_1 connector: GPS\_ \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| VCC\\_5V \| in \| red \| Supply to GPS from AP \| \| 2 \| GPS\\_RX \| in \| black \| 3.3V-5.0V TTL level, TX of AP \| \| 3 \| GPS\\_TX \| out \| black \| 3.3V-5.0V TTL level, RX of AP \| \| 4 \| SCL \| in \| black \| 3.3V-5.0V I2C1 \| \| 5 \| SDA \| in/out \| black \| 3.3V-5.0V I2C1 \| \| 6 \| BUTTON \| out \| black \| Signal shorted to GND on press \| \| 7 \| BUTTON\\_LED \| out \| black \| LED Driver for Safety Button \| \| 8 \| GND \| - \| black \| GND connection \| \*\*UART 4 \\(I2C 2, the original “Internal” bus\\)\*\* \_1 connector: GPS\_ \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| VCC\\_5V \| out \| red / gray \| Supply to GPS from AP \| \| 2 \| MCU\\_TX \| out \| yellow / black \| 3.3V-5.0V TTL level, TX of AP \| \| 3 \| MCU\\_RX \| in \| green / black \| 3.3V-5.0V TTL level, RX of AP \| \| 4 \| SCL \| out \| gray / black \| 3.3V-5.0V I2C2 \| \| 5 \| SDA \| in \| gray / black \| 3.3V-5.0V I2C2 \| \| 6 \| GND \| - \| black \| GND connection \| \*\*UART 5\\(Debug\\) and S.Bus out\*\* Original Carrier board \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| S.Bus Out \| out \| \| 3.3V-5.0V TTL level, TX of AP \| \| 2 \| MCU\\_TX \| out \| \| 3.3V-5.0V TTL level, TX of AP \| \| 3 \| VDD\\_Servo \| OUT \| \| Servo rail voltage \| \| 4 \| MCU\\_RX \| in \| \| 3.3V-5.0V TTL level, RX of AP \| \| 5 \| GND \| out \| \| GND \| \| 6 \| GND \| out \| \| GND \| \*\*S.Bus out\*\* New ADSB Carrier board \| \*\*Pin \\#\*\* \| \*\*Name\*\* \| \*\*Dir\*\* \| \*\*Wire Color\*\* \| \*\*Description\*\* \| \| :--- \| :--- \| :--- \| :--- \| :--- \| \| 1 \| S.Bus Out \| out \| \| 3.3V-5.0V TTL level, TX of AP \| \| 2 \| \| \| \| \| \| 3 \| VDD\\_Servo \| OUT \| \| Servo rail voltage \| \| 4 \| \| \| \| \| \| 5 \| GND \| out \| \| GND \| \| 6 \| GND \| out \| \| GND \| \*\*Debug \\( New Standard Debug\\) \\(Digikey PN for housing SM06B-SURS-TF\\(LF\\)\\(SN\\)-ND\\)\*\* \*\*\*IO DEBUG\*\*\*
+1. _connector: I2C2 bus_
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** | 
+| :--- | :--- | :--- | :--- | :--- | 
+| 1 | VCC\_5V | out | red / gray | Supply to peripheral from AP |
+| 2 | SCL | in/out | blue / black | SCL, 5V level, pull-up on AP |
+| 3 | SDA | in/out | green / black | SDA, 5V level, pull-up on AP |
+| 4 | GND | - | black | GND connection |
 
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left"><b>Pin #</b>
-      </th>
-      <th style="text-align:left"><b>Name</b>
-      </th>
-      <th style="text-align:left"><b>Dir</b>
-      </th>
-      <th style="text-align:left"><b>Wire Color</b>
-      </th>
-      <th style="text-align:left"><b>Description</b>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="text-align:left">1</td>
-      <td style="text-align:left">VDD 5V PEIPH</td>
-      <td style="text-align:left">OUT</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">5V</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">2</td>
-      <td style="text-align:left">IO_TX</td>
-      <td style="text-align:left">out</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">
-        <p>3.3V-5.0V TTL level, TX of AP</p>
-        <p>IO_uart1 TX</p>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">3</td>
-      <td style="text-align:left">IO_RX</td>
-      <td style="text-align:left">in</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">3.3V - 5.0V TTL level, RX of AP IO_uart1 RX</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">4</td>
-      <td style="text-align:left">IO-SWDIO</td>
-      <td style="text-align:left">I/O</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">Serial wire debug I/O</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">5</td>
-      <td style="text-align:left">IO-SWCLK</td>
-      <td style="text-align:left">I/O</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">Serial wire Clock</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">6</td>
-      <td style="text-align:left">GND</td>
-      <td style="text-align:left">out</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">GND</td>
-    </tr>
-  </tbody>
-</table>**FMU DEBUG**
+**CAN \(2 fitted\)**
 
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left"><b>Pin #</b>
-      </th>
-      <th style="text-align:left"><b>Name</b>
-      </th>
-      <th style="text-align:left"><b>Dir</b>
-      </th>
-      <th style="text-align:left"><b>Wire Color</b>
-      </th>
-      <th style="text-align:left"><b>Description</b>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="text-align:left">1</td>
-      <td style="text-align:left">VDD 5V PEIPH</td>
-      <td style="text-align:left">OUT</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">5V</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">2</td>
-      <td style="text-align:left">FMU_TX (SERIAL 5)</td>
-      <td style="text-align:left">out</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">3.3V-5.0V TTL level, TX of AP FMU_uart5 TX</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">3</td>
-      <td style="text-align:left">FMU_RX (SERIAL 5)</td>
-      <td style="text-align:left">in</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">
-        <p>3.3V-5.0V TTL level, RX of AP</p>
-        <p>FMU_uart5 RX</p>
-      </td>
-    </tr>
-    <tr>
-      <td style="text-align:left">4</td>
-      <td style="text-align:left">FMU-SWDIO</td>
-      <td style="text-align:left">I/O</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">Serial wire debug I/O</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">5</td>
-      <td style="text-align:left">FMU-SWCLK</td>
-      <td style="text-align:left">I/O</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">Serial wire Clock</td>
-    </tr>
-    <tr>
-      <td style="text-align:left">6</td>
-      <td style="text-align:left">GND</td>
-      <td style="text-align:left">out</td>
-      <td style="text-align:left"></td>
-      <td style="text-align:left">GND</td>
-    </tr>
-  </tbody>
-</table>**Analogue**
+1. _connectors: CAN1 and CAN2 buses_ 
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | VCC\_5V | out | red / gray | Supply to peripheral from AP |
+| 2 | CAN\_H | in/out | yellow / black | 12V |
+| 3 | CAN\_L | in/out | green / black | 12V |
+| 4 | GND | - | black | GND connection |
+
+**UART GENERIC \(autopilot side\)**
+
+_2 connectors: TELEM1, TELEM2_
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | VCC\_5V | out | red / gray | Supply to GPS from AP |
+| 2 | MCU\_TX | out | yellow / black | 3.3V-5.0V TTL level, TX of AP |
+| 3 | MCU\_RX | in | green / black | 3.3V-5.0V TTL level, RX of AP |
+| 4 | MCU\_CTS \(TX\) | out | gray / black | 3.3V-5.0V TTL level or TX of AP |
+| 5 | MCU\_RTS \(RX\) | in | gray / black | 3.3V-5.0V TTL level or RX of AP |
+| 6 | GND | - | black | GND connection |
+
+**UART GPS \(autopilot side, I2C is the original “External” bus\)**
+
+_1 connector: GPS_
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | VCC\_5V | in | red | Supply to GPS from AP |
+| 2 | GPS\_RX | in | black | 3.3V-5.0V TTL level, TX of AP |
+| 3 | GPS\_TX | out | black | 3.3V-5.0V TTL level, RX of AP |
+| 4 | SCL | in | black | 3.3V-5.0V I2C1 |
+| 5 | SDA | in/out | black | 3.3V-5.0V I2C1 |
+| 6 | BUTTON | out | black | Signal shorted to GND on press |
+| 7 | BUTTON\_LED | out | black | LED Driver for Safety Button |
+| 8 | GND | - | black | GND connection |
+
+**UART 4 \(I2C 2, the original “Internal” bus\)**
+
+_1 connector: GPS_
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | VCC\_5V | out | red / gray | Supply to GPS from AP |
+| 2 | MCU\_TX | out | yellow / black | 3.3V-5.0V TTL level, TX of AP |
+| 3 | MCU\_RX | in | green / black | 3.3V-5.0V TTL level, RX of AP |
+| 4 | SCL | out | gray / black | 3.3V-5.0V I2C2 |
+| 5 | SDA | in | gray / black | 3.3V-5.0V I2C2 |
+| 6 | GND | - | black | GND connection |
+
+**UART 5 \(Debug and S.Bus out\)**
+
+_Original Carrier board_
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | S.Bus Out | out | | 3.3V-5.0V TTL level, TX of AP |
+| 2 | MCU\_TX | out | | 3.3V-5.0V TTL level, TX of AP |
+| 3 | VDD\_Servo | OUT | | Servo rail voltage |
+| 4 | MCU\_RX | in | | 3.3V-5.0V TTL level, RX of AP |
+| 5 | GND | out | | GND |
+| 6 | GND | out | | GND |
+
+**S.Bus out**
+New ADSB Carrier board
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | S.Bus Out | out | | 3.3V-5.0V TTL level, TX of AP |
+| 2 | | | ||
+| 3 | VDD\_Servo | OUT | | Servo rail voltage |
+| 4 | | | | |
+| 5 | GND | out | | GND |
+| 6 | GND | out | | GND |
+
+**Debug \( New Standard Debug\) \(Digikey PN for housing SM06B-SURS-TF\(LF\)\(SN\)-ND\)**
+
+***IO DEBUG***
+
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :---| :---| :--- | :---|
+| 1 | VDD 5V PEIPH | OUT | | 5V |
+| 2 | IO_TX | OUT | | 3.3V - 5.0V TTL level, TX of AP<br/>IO_uart1 TX |
+| 3 | IO_RX | IN | | 3.3V - 5.0V TTL level, RX of AP<br/>IO_uart1 RX |
+| 4 | IO-SWDIO | I/O | | Serial Wire Debug I/O |
+| 5 | IO-SWCLK | I/O | | Serial Wire Clock |
+| 6 | GND | OUT | | GND |
+
+**FMU DEBUG**
+
+| **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
+| :--- | :---| :---| :--- | :---|
+| 1 | VDD 5V PEIPH | OUT | | 5V |
+| 2 | FMU_TX \(SERIAL 5\) | OUT | | 3.3V-5.0V TTL level, TX of AP FMU_uart5 TX |
+| 3 | FMU_RX \(SERIAL 5\) | IN |  | 3.3V-5.0V TTL level, RX of AP<br/>FMU_uart5 RX |
+| 4 | FMU-SWDIO | I/O |  | Serial wire debug I/O |
+| 5 | FMU-SWCLK | I/O |  | Serial wire Clock |
+| 6 | GND | out |  | GND |
+
+**Analogue**
 
 | **Pin \#** | **Name** | **Dir** | **Wire Color** | **Description** |
 | :--- | :--- | :--- | :--- | :--- |
@@ -387,335 +402,86 @@ _**SERVO HEADER \(0.1”, 1/1/15 power layout\)**_
 
 | **Pin \#** | **Name** | **Dir** | **Description** |
 | :--- | :--- | :--- | :--- |
-
-
 | 1 | FMU-SWDIO | i/o | Single wire debug io |
-| :--- | :--- | :--- | :--- |
-
-
 | 2 | !FMU- LED\_AMBER | o | Boot error LED \( drive only, use Fet to control led\) |
-| :--- | :--- | :--- | :--- |
-
-
 | 3 | FMU-SWCLK | o | single wire debug clock |
-| :--- | :--- | :--- | :--- |
-
-
 | 4 | I2C\_2\_SDA | i/o | I2C data io |
-| :--- | :--- | :--- | :--- |
-
-
 | 5 | !EXTERN\_CS | o | chip select for external SPI \(NC, just for debugging\) |
-| :--- | :--- | :--- | :--- |
-
-
 | 6 | I2C\_2\_SCL | o | i2c clock |
-| :--- | :--- | :--- | :--- |
-
-
 | 7 | FMU-!RESET | i | reset pin for the FMU |
-| :--- | :--- | :--- | :--- |
-
-
 | 8 |  |  | Future compatibility |
-| :--- | :--- | :--- | :--- |
-
-
 | 9 | VDD\_SERVO\_IN | i | power for last resort i/o failsafe |
-| :--- | :--- | :--- | :--- |
-
-
 | 10 |  |  | Future compatibility |
-| :--- | :--- | :--- | :--- |
-
-
 | 11 | EXTERN\_DRDY | i | interrupt pin for external SPI \(NC, just for debugging\) |
-| :--- | :--- | :--- | :--- |
-
-
 | 12 | SERIAL\_5\_RX | i |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 13 | GND |  | System GND |
-| :--- | :--- | :--- | :--- |
-
-
 | 14 | SERIAL\_5\_TX | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 15 | GND |  | System GND |
-| :--- | :--- | :--- | :--- |
-
-
 | 16 | SERIAL\_4\_RX | i |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 17 | SAFETY |  | Safety button input |
-| :--- | :--- | :--- | :--- |
-
-
 | 18 | SERIAL\_4\_TX | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 19 | vdd\_3V3\_SPECT RUM\_EN | o | enable for the spectrum voltage regulator |
-| :--- | :--- | :--- | :--- |
-
-
 | 20 | SERIAL\_3\_RX | i |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 21 | PREASSURE\_SE NS\_IN | a i | Analogue port, for pressure sensor, or Laser range finder, or Sonar |
-| :--- | :--- | :--- | :--- |
-
-
 | 22 | SERIAL\_3\_TX | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 23 | AUX\_BATT\_VOL TAGE\_SENS | a i | Voltage sense for Aux battery input |
-| :--- | :--- | :--- | :--- |
-
-
 | 24 | ALARM | o | Buzzer PWM signal |
-| :--- | :--- | :--- | :--- |
-
-
 | 25 | AUX\_BATT\_CUR | a i | Current sense for Aux battery input |
-| :--- | :--- | :--- | :--- |
-
-
 |  | RENT\_SENS |  |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 26 | IO-VDD\_3V3 | i | IO chip power, pinned through for debug |
-| :--- | :--- | :--- | :--- |
-
-
 | 27 | !VDD\_5V\_PERIP H\_EN | o | enable signal for Peripherals |
-| :--- | :--- | :--- | :--- |
-
-
 | 28 | !IO- LED\_SAFETY\_P ROT | o | IO-LED\_SAFETY pinned out for IRIS |
-| :--- | :--- | :--- | :--- |
-
-
 | 29 | VBUS | i | vbus, voltage from USB plug |
-| :--- | :--- | :--- | :--- |
-
-
 | 30 | SERIAL2\_RTS |  |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 31 | OTG\_DP1 | i/o | DATA P from USB |
-| :--- | :--- | :--- | :--- |
-
-
 | 32 | SERIAL2\_CTS |  |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 33 | OTG\_DM1 | i/o | DATA M from USB |
-| :--- | :--- | :--- | :--- |
-
-
 | 34 | SERIAL2\_RX | i |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 35 | I2C\_1\_SDA | i/o | I2C data i/o |
-| :--- | :--- | :--- | :--- |
-
-
 | 36 | SERIAL2\_TX | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 37 | I2C\_1\_SCL | o | I2C clock |
-| :--- | :--- | :--- | :--- |
-
-
 | 38 | SERIAL1\_RX | i |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 39 | CAN\_L\_2 | i/o | Canbus Low signal driver on FMU |
-| :--- | :--- | :--- | :--- |
-
-
 | 40 | SERIAL1\_TX | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 41 | CAN\_H\_2 | i/o | Canbus High signal driver on FMU |
-| :--- | :--- | :--- | :--- |
-
-
 | 42 | SERIAL1\_RTS |  |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 43 | !VDD\_5V\_PERIP H\_OC | i | error state message from Periph power supply |
-| :--- | :--- | :--- | :--- |
-
-
 | 44 | SERIAL1\_CTS |  |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 45 | !VDD\_5V\_HIPOW ER\_OC | i | error state message from High power Periph power supply |
-| :--- | :--- | :--- | :--- |
-
-
 | 46 | IO-USART1\_TX | o |  |
-| :--- | :--- | :--- | :--- |
-
-
-<table>
-  <thead>
-    <tr>
-      <th style="text-align:left">47</th>
-      <th style="text-align:left">
-        <p>BATT_VOLTAGE</p>
-        <p>_SENS_PROT</p>
-      </th>
-      <th style="text-align:left">a i</th>
-      <th style="text-align:left">Voltage sense from main battery</th>
-    </tr>
-  </thead>
-  <tbody></tbody>
-</table>| 50 | FMU-CH1-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
+| 47 | BATT_VOLTAGE<br/>_SENS_PROT | a i | Voltage sense from main battery |
+| 50 | FMU-CH1-PROT | o |  |
 | 51 | SPI\_EXT\_MOSI | o | External SPI, for debug only |
-| :--- | :--- | :--- | :--- |
-
-
 | 52 | FMU-CH2-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 53 | VDD\_SERVO | i | VDD\_Servo, for monitoring servo bus |
-| :--- | :--- | :--- | :--- |
-
-
 | 54 | FMU-CH3-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 55 | !VDD\_BRICK\_VALID | i | main power valid signal |
-| :--- | :--- | :--- | :--- |
-
-
 | 56 | FMU-CH4-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 57 | !VDD\_BACKUP\_VALID | i | backup power valid signal |
-| :--- | :--- | :--- | :--- |
-
-
 | 58 | FMU-CH5-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 59 | !VBUS\_VALID | i | USB bus valid signal |
-| :--- | :--- | :--- | :--- |
-
-
 | 60 | FMU-CH6-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 61 | VDD\_5V\_IN | i | main power into FMU from power selection |
-| :--- | :--- | :--- | :--- |
-
-
 | 62 | PPM-SBUS-PROT | i |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 63 | VDD\_5V\_IN | i | main power into FMU from power selection |
-| :--- | :--- | :--- | :--- |
-
-
 | 64 | S.BUS\_OUT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 65 | IO-VDD\_5V5 | o | power to RX |
-| :--- | :--- | :--- | :--- |
-
-
 | 66 | IO-CH8-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 67 | SPI\_EXT\_MISO | i | External SPI, for debug only |
-| :--- | :--- | :--- | :--- |
-
-
 | 68 | IO-CH7-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 69 | IO-SWDIO | i/o | IO single wire debug i/o |
-| :--- | :--- | :--- | :--- |
-
-
 | 70 | IO-CH6-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 71 | IO-SWCLK | o | IO single wire debug clock |
-| :--- | :--- | :--- | :--- |
-
-
 | 72 | IO-CH5-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 73 | SPI\_EXT\_SCK | o | External SPI, for debug only |
-| :--- | :--- | :--- | :--- |
-
-
 | 74 | IO-CH4-PROT | i |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 75 | IO-!RESET | i | IO reset pin |
-| :--- | :--- | :--- | :--- |
-
-
 | 76 | IO-CH3-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 77 | CAN\_L\_1 | i/o | Canbus Low signal driver on FMU |
-| :--- | :--- | :--- | :--- |
-
-
 | 78 | IO-CH2-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 | 79 | CAN\_H\_1 | i/o | Canbus High signal driver on FMU |
-| :--- | :--- | :--- | :--- |
-
-
 | 80 | IO-CH1-PROT | o |  |
-| :--- | :--- | :--- | :--- |
-
-
 |  |
-| :--- |
 
 
 ## Differences between Cube colours


### PR DESCRIPTION
Update the cube module overview to clean up poorly formatted html and markdown rendering.

Also updated the links in "Interface Standard" to point to the correct page, or for DF17, to the Hirose product page for DF17 connectors.